### PR TITLE
Modify the build process to leverage multi-stage Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
+FROM golang:1.9.1-alpine3.6 as builder
+RUN apk add git --no-cache
+RUN go get -u github.com/fgeller/kt
+
+
 FROM alpine:3.6
-
 MAINTAINER Pavel Evstigneev <pavel.evst@gmail.com>
-
-ADD kt /usr/bin
-
-CMD ["/usr/bin/kt"]
+COPY --from=builder /go/bin/kt /usr/bin
+ENTRYPOINT ["/usr/bin/kt"]

--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -1,8 +1,0 @@
-FROM golang:1.8.3-alpine3.6
-
-MAINTAINER Pavel Evstigneev <pavel.evst@gmail.com>
-
-RUN apk add git --no-cache
-
-RUN go get -u github.com/fgeller/kt
-

--- a/README.md
+++ b/README.md
@@ -11,17 +11,16 @@ Image size: 4 MB compressed, 11 MB uncompressed
 ### Usage
 
 ```
-docker run evpavel/kt kt topic -brokers my-kafka-server:9092
+docker run evpavel/kt topic -brokers my-kafka-server:9092
 ```
 
 ### How it works
 
-1. Build image from `Dockerfile.compile`
-2. Copy compiled `kt` binary
-3. Build small image with only `kt` binary
+1. Build image from `Dockerfile` using [multi-stage builds](https://docs.docker.com/engine/userguide/eng-image/multistage-build/)
+2. Build small image with only `kt` binary
 
 ### Build
 
 ```
-./build_all.sh
+./build.sh
 ```

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+docker build -t=evpavel/kt:latest .
+docker tag evpavel/kt:latest evpavel/kt:0.1

--- a/build_all.sh
+++ b/build_all.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-docker build . -f Dockerfile.compile -t kt-compiled
-docker run -it kt-compiled kt --help
-LAST_CONTAINER_ID=$(docker ps -a | grep kt-compiled | head -1 | awk '{print $1;}')
-docker cp $LAST_CONTAINER_ID:/go/bin/kt .
-
-docker build . -t evpavel/kt:latest
-docker build . -t evpavel/kt:0.1


### PR DESCRIPTION
Hello,

I modified the build process to use multi-stage builds. This offers an easy way to build images while being able to have tiny images. 

Instead of having 2 or more Dockerfile you only have one. More information here https://docs.docker.com/engine/userguide/eng-image/multistage-build/

I also added an entrypoint to the Docker image to ease its usage. And last but not least, I modified and renamed the `build_all.sh` script. 

Cheers